### PR TITLE
Adding Hare Quota method

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2.2-1 (5/2/2021)
+stv: Added feature to select Hare method of quota calculation (quota.hare) and 
+default remains Droop quota method (thanks to moryall).
+
 2.2-0 (2/11/2021)
 -----
 stv: Added feature of reserving seats for a subgroup (arguments group.mcan, group.members)

--- a/R/stv.R
+++ b/R/stv.R
@@ -132,7 +132,7 @@ stv <- function(votes, mcan = NULL, eps = 0.001, equal.ranking = FALSE,
 		names(vcast) <- cnames
 		if(!constant.quota || count == 1)
 		# Droop and Hare test control. If true will run Hare or if false/default to Droop method
-		    if(!quota.hare == TRUE){
+		    if(!quota.hare == FALSE){
 		      quota <- sum(vcast)/(mcan) + eps} else {
 		      quota <- sum(vcast)/(mcan + 1) + eps}
 

--- a/R/stv.R
+++ b/R/stv.R
@@ -2,7 +2,7 @@ stv <- function(votes, mcan = NULL, eps = 0.001, equal.ranking = FALSE,
                 fsep = '\t', ties = c("f", "b"), constant.quota = FALSE,
                 group.mcan = NULL, group.members = NULL,
                 complete.ranking = FALSE, verbose = FALSE, seed = 1234, 
-                quiet = FALSE, digits = 3, ...) {
+                quiet = FALSE, digits = 3, quota.hare = FALSE, ...) {
 	###################################
 	# Single transferable vote.
 	# Adopted from Bernard Silverman's code.
@@ -131,7 +131,11 @@ stv <- function(votes, mcan = NULL, eps = 0.001, equal.ranking = FALSE,
 		vcast <- apply(uij, 2, sum)
 		names(vcast) <- cnames
 		if(!constant.quota || count == 1)
-		    quota <- sum(vcast)/(mcan + 1) + eps
+		# Droop and Hare test control. If true will run Hare or if false/default to Droop method
+		    if(!quota.hare == TRUE){
+		      quota <- sum(vcast)/(mcan) + eps} else {
+		      quota <- sum(vcast)/(mcan + 1) + eps}
+
 		result.quota <- c(result.quota, quota)
 		result.pref <- rbind(result.pref, vcast)
 		result.elect <- rbind(result.elect, rep(0,nc))

--- a/man/stv.Rd
+++ b/man/stv.Rd
@@ -51,6 +51,8 @@ ordered.preferences(vmat)
   \item{mcan}{Number of candidates to be elected. By default it is half the number of candidates standing.}
   \item{eps}{Value added to the quota. I.e. the STV quota is computed as \cr
   	\code{number_of_first_preferences/(number_of_seats + 1) + eps}.}
+  \item{quota.hare}{Changes quota calculation from Droop (default) \code{FALSE} to Hare \code{TRUE}. STV Hare quota method is computed as \cr
+    \code{number_of_first_preferences/(number_of_seats) + eps}.}
   \item{equal.ranking}{If \code{TRUE} equal preferences are allowed, see below.}
   \item{fsep}{If \code{votes} is a file name, this argument gives the column separator in the file.}
   \item{ties}{Method used to break ties. By default the forwards tie-breaking is used (\dQuote{f}). Value \dQuote{b} invokes the backwards tie-breaking method, see O'Neill (2004).}

--- a/man/stv.Rd
+++ b/man/stv.Rd
@@ -52,7 +52,7 @@ ordered.preferences(vmat)
   \item{eps}{Value added to the quota. I.e. the STV quota is computed as \cr
   	\code{number_of_first_preferences/(number_of_seats + 1) + eps}.}
   \item{quota.hare}{Changes quota calculation method from Droop (default) \code{FALSE} to Hare \code{TRUE}. STV Hare quota method is computed as \cr
-    \code{number_of_first_preferences/(number_of_seats) + eps}. True Hare formula would entail \code{eps = 0}.}
+    \code{number_of_first_preferences/(number_of_seats) + eps}. The actual Hare formula would entail \code{eps = 0}.}
   \item{equal.ranking}{If \code{TRUE} equal preferences are allowed, see below.}
   \item{fsep}{If \code{votes} is a file name, this argument gives the column separator in the file.}
   \item{ties}{Method used to break ties. By default the forwards tie-breaking is used (\dQuote{f}). Value \dQuote{b} invokes the backwards tie-breaking method, see O'Neill (2004).}

--- a/man/stv.Rd
+++ b/man/stv.Rd
@@ -51,8 +51,8 @@ ordered.preferences(vmat)
   \item{mcan}{Number of candidates to be elected. By default it is half the number of candidates standing.}
   \item{eps}{Value added to the quota. I.e. the STV quota is computed as \cr
   	\code{number_of_first_preferences/(number_of_seats + 1) + eps}.}
-  \item{quota.hare}{Changes quota calculation from Droop (default) \code{FALSE} to Hare \code{TRUE}. STV Hare quota method is computed as \cr
-    \code{number_of_first_preferences/(number_of_seats) + eps}.}
+  \item{quota.hare}{Changes quota calculation method from Droop (default) \code{FALSE} to Hare \code{TRUE}. STV Hare quota method is computed as \cr
+    \code{number_of_first_preferences/(number_of_seats) + eps}. True Hare formula would entail \code{eps = 0}.}
   \item{equal.ranking}{If \code{TRUE} equal preferences are allowed, see below.}
   \item{fsep}{If \code{votes} is a file name, this argument gives the column separator in the file.}
   \item{ties}{Method used to break ties. By default the forwards tie-breaking is used (\dQuote{f}). Value \dQuote{b} invokes the backwards tie-breaking method, see O'Neill (2004).}


### PR DESCRIPTION
I implemented an option to select the Hare quota method in addition to the initially programmed Droop quota method. I left it so the default is the Droop method as originally specified so it should not disturb any previous version's scripts. I am very novice at programming but I wanted to add this as a feature to an otherwise fantastic library.